### PR TITLE
Use either GH_TOKEN or GITHUB_TOKEN

### DIFF
--- a/git-pulse
+++ b/git-pulse
@@ -779,7 +779,7 @@ else
 fi
 
 if [ -n "$token" ]; then
-  authorizationHeader="Authorization: token $GITHUB_TOKEN"
+  authorizationHeader="Authorization: token $token"
 fi
 
 issuesClosedArray=()


### PR DESCRIPTION
Before this change, even if $GH_TOKEN was set $GITHUB_TOKEN was used